### PR TITLE
FIX: git reset before checking out on new container

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -404,6 +404,7 @@ func checkoutBranch(cmd *cobra.Command, cfg config.Config, name, workdir, branch
 		script := fmt.Sprintf(`
 set -e
 echo "Checking out %s..."
+git reset --hard > /tmp/dv-git-reset.log 2>&1 || true
 git checkout %s > /tmp/dv-git-checkout.log 2>&1
 echo "Pulling latest..."
 git pull > /tmp/dv-git-pull.log 2>&1


### PR DESCRIPTION
During provisioning, dv starts from the built image and performs a `git checkout`, fetching the latest code. However, the built image could have uncommitted changes (i.e. updates Gemfile.lock from bundle install). This may conflict with the checkout process, resulting in the provisioning failing. This commit adds a `git reset --hard` to ensure its subsequent checkouts and pulls are clean.