### PR TITLE
DEV: Make command groups for bare dv CLI call

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,12 +30,21 @@ func addPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 }
 
+// Command group IDs used to organize root help output.
+const (
+	groupDaily     = "daily"
+	groupLifecycle = "lifecycle"
+	groupCode      = "code"
+	groupTools     = "tools"
+)
+
 func init() {
 	addPersistentFlags(rootCmd)
 
 	// Custom usage template that keeps the command list aligned by padding only the
 	// primary command name; aliases are shown after the description to avoid
-	// breaking column alignment.
+	// breaking column alignment. Commands render under their registered groups;
+	// any ungrouped command falls back to "Additional Commands".
 	rootCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
@@ -44,11 +53,17 @@ Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
 
 Available Commands:
-{{range .Commands}}{{if .IsAvailableCommand}}
-  {{rpad .Name .NamePadding}} {{.Short}}{{if gt (len .Aliases) 0}} (aliases: {{.Aliases}}){{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{range $cmds}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding}} {{.Short}}{{if gt (len .Aliases) 0}} (aliases: {{.Aliases}}){{end}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{$group.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) .IsAvailableCommand)}}
+  {{rpad .Name .NamePadding}} {{.Short}}{{if gt (len .Aliases) 0}} (aliases: {{.Aliases}}){{end}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") .IsAvailableCommand)}}
+  {{rpad .Name .NamePadding}} {{.Short}}{{if gt (len .Aliases) 0}} (aliases: {{.Aliases}}){{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
@@ -62,6 +77,30 @@ Additional help topics:
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `)
+
+	rootCmd.AddGroup(
+		&cobra.Group{ID: groupDaily, Title: "Daily Use:"},
+		&cobra.Group{ID: groupLifecycle, Title: "Container Lifecycle:"},
+		&cobra.Group{ID: groupCode, Title: "Code & Plugins:"},
+		&cobra.Group{ID: groupTools, Title: "Tools & Maintenance:"},
+	)
+	// The auto-generated help command must belong to a group, otherwise the
+	// template renders an empty "Additional Commands" heading for it.
+	rootCmd.SetHelpCommandGroupID(groupTools)
+
+	// branchCmd, prCmd, and upgradeCmd are registered in their own files but
+	// grouped here so the whole layout is visible in one place.
+	groups := map[string][]*cobra.Command{
+		groupDaily:     {enterCmd, restartCmd, resetCmd, runCmd, runAgentCmd, tuiCmd, branchCmd, prCmd, catchupCmd, copyCmd},
+		groupLifecycle: {newCmd, startCmd, stopCmd, removeCmd, listCmd, selectCmd, renameCmd, psCmd},
+		groupCode:      {importCmd, extractCmd, pluginCmd},
+		groupTools:     {buildCmd, pullCmd, imageCmd, exposeCmd, mailCmd, serveCmd, configCmd, dataCmd, updateCmd, upgradeCmd, versionCmd},
+	}
+	for groupID, cmds := range groups {
+		for _, c := range cmds {
+			c.GroupID = groupID
+		}
+	}
 
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(startCmd)


### PR DESCRIPTION
Groups available commands when running dv so you can
parse the list a bit easier, especially helpful for
common commands you're running all the time:

```
Discourse Vibe: manage local Discourse dev containers

Usage:
  dv [command]

Daily Use:
  branch         Checkout a branch in the container (resets DB by default)
  catchup        Pull latest code and migrate databases
  copy           Copy files between host and container (aliases: [cp])
  enter          Enter the container as 'discourse' (use --root for root)
  pr             Checkout a PR in the container (resets DB by default)
  reset          Reset container state (databases or git)
  restart        Restart the container or internal discourse services (rails, ember, etc.)
  run            Run a command inside the container as 'discourse' (use --root for root)
  run-agent      Run an AI agent inside the container with a prompt or prompt file (aliases: [ra])
  tui            Open the interactive TUI

Container Lifecycle:
  list           List containers created from the selected image (aliases: [ls])
  new            Create a new agent for the selected image and select it
  ps             Show active exec sessions in a container
  remove         Remove container and optionally its image (aliases: [rm])
  rename         Rename an existing agent container
  select         Select an existing (or future) agent by name
  start          Create or start a container for the selected image
  stop           Stop the container or internal discourse services (rails, ember, etc.)

Code & Plugins:
  extract        Extract changes from container's code tree into local repo
  import         Import local git commits and working changes into the container
  plugin         Manage plugins in the selected Discourse agent

Tools & Maintenance:
  build          Build a configured image, a stock image, or a Dockerfile path
  config         Manage dv configuration
  data           Show data directory path
  expose         Expose container on public network interfaces for testing
  image          Manage dv images (list, select, add, remove, set, show)
  mail           Run MailHog and tunnel it to localhost
  pull           Pull a prebuilt dv Docker image instead of building locally
  serve          Run a dv HTTP API server
  update         Update tooling inside the container
  upgrade        Upgrade the dv binary to the latest release
  version        Print version information

Flags:
  -h, --help      help for dv
  -v, --verbose   Enable verbose output

Use "dv [command] --help" for more information about a command.
```
