### PR TITLE
DEV: Add a dv console command

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"dv/internal/docker"
+)
+
+var consoleCmd = &cobra.Command{
+	Use:   "console [NAME]",
+	Short: "Open a Rails console in the container",
+	Args:  cobra.MaximumNArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// Complete container name for the first positional argument
+		if len(args) == 0 {
+			return completeAgentNames(cmd, toComplete)
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var containerName string
+		if len(args) > 0 {
+			containerName = args[0]
+		}
+
+		ctx, ok, err := prepareContainerExecContext(cmd, containerName)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+
+		// Label the pry prompt with the container name (e.g. "[1] dv:agent(main)>")
+		// so it's obvious the console is running inside a dv container. Pry reads
+		// the rc file pointed at by PRYRC instead of ~/.pryrc.
+		rcLine := fmt.Sprintf("Pry.config.prompt_name = %q", "dv:"+ctx.name)
+		script := fmt.Sprintf("echo %s > /tmp/.dv-pryrc && PRYRC=/tmp/.dv-pryrc exec bin/rails console", shellQuote(rcLine))
+		execArgs := []string{"bash", "-lc", script}
+		return docker.ExecInteractive(ctx.name, ctx.workdir, ctx.envs, execArgs)
+	},
+}
+
+func init() {
+	consoleCmd.Flags().String("name", "", "Container name (defaults to selected or default)")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -66,6 +66,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(enterCmd)
+	rootCmd.AddCommand(consoleCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(runAgentCmd)
 	rootCmd.AddCommand(copyCmd)


### PR DESCRIPTION
Running this will land you in the rails console
in the container. For a bonus we set the pry prompt
so you know you're in a dv container:

```
$ dv console

Loading development environment (Rails 8.0.5)
[1] dv:hades(main)>
```
