### PR TITLE
fix(cli): stop port search on bind errors

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -396,9 +396,9 @@ func handleContainerCreate(w http.ResponseWriter, r *http.Request, configDir str
 		}
 		if !docker.Exists(name) {
 			allocated, _ := docker.AllocatedPorts()
-			chosenPort := hostPort
-			for isPortInUse(chosenPort, allocated) {
-				chosenPort++
+			chosenPort, err := findAvailableHostPort(hostPort, allocated)
+			if err != nil {
+				return err
 			}
 			if chosenPort != hostPort {
 				logger(fmt.Sprintf("Port %d in use, using %d.\n", hostPort, chosenPort))
@@ -596,9 +596,9 @@ func handleContainerStart(w http.ResponseWriter, r *http.Request, configDir, nam
 		}
 		if !docker.Exists(name) {
 			allocated, _ := docker.AllocatedPorts()
-			chosenPort := cfg.HostStartingPort
-			for isPortInUse(chosenPort, allocated) {
-				chosenPort++
+			chosenPort, err := findAvailableHostPort(cfg.HostStartingPort, allocated)
+			if err != nil {
+				return err
 			}
 			labels := map[string]string{
 				"com.dv.owner":      "dv",

--- a/internal/cli/shared.go
+++ b/internal/cli/shared.go
@@ -1,13 +1,16 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -30,7 +33,10 @@ var (
 		fmt.Fprintln(os.Stderr, "Warning: stale session selection ignored; falling back to selected agent.")
 	}
 	staleSessionWarnOnce sync.Once
+	listenTCP            = net.Listen
 )
+
+const maxTCPPort = math.MaxUint16
 
 // isTruthyEnv returns true for truthy environment variable values.
 func isTruthyEnv(key string) bool {
@@ -136,39 +142,66 @@ func resolveImage(cfg config.Config, override string) (string, config.ImageConfi
 	return name, img, nil
 }
 
-// isPortInUse returns true when the given TCP port cannot be bound on localhost
-// or is already allocated to a Docker container.
-func isPortInUse(port int, dockerAllocated map[int]bool) bool {
+// isPortInUse reports whether a valid TCP port is already bound locally or is
+// allocated to a Docker container. Bind failures other than EADDRINUSE are
+// returned so callers do not mistake a restricted network sandbox for a run of
+// occupied ports.
+func isPortInUse(port int, dockerAllocated map[int]bool) (bool, error) {
+	if port < 1 || port > maxTCPPort {
+		return false, fmt.Errorf("TCP port %d is outside the valid range 1-%d", port, maxTCPPort)
+	}
 	if dockerAllocated != nil && dockerAllocated[port] {
 		if isTruthyEnv("DV_VERBOSE") {
 			fmt.Fprintf(os.Stderr, "Port %d is already allocated by a Docker container\n", port)
 		}
-		return true
+		return true, nil
 	}
 	// Try to listen on all interfaces. This is the most conservative check.
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := listenTCP("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
+		if !errors.Is(err, syscall.EADDRINUSE) {
+			return false, fmt.Errorf("checking TCP port %d: %w", port, err)
+		}
 		if isTruthyEnv("DV_VERBOSE") {
 			fmt.Fprintf(os.Stderr, "Port %d is in use (Listen :%d failed: %v)\n", port, port, err)
 		}
-		return true
+		return true, nil
 	}
 	_ = l.Close()
 
 	// Also specifically check 127.0.0.1 and [::1] because sometimes ':' only
 	// binds to one of them depending on system configuration.
 	for _, host := range []string{"127.0.0.1", "[::1]"} {
-		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+		l, err := listenTCP("tcp", fmt.Sprintf("%s:%d", host, port))
 		if err != nil {
+			if !errors.Is(err, syscall.EADDRINUSE) {
+				return false, fmt.Errorf("checking TCP port %d on %s: %w", port, host, err)
+			}
 			if isTruthyEnv("DV_VERBOSE") {
 				fmt.Fprintf(os.Stderr, "Port %d is in use (Listen %s:%d failed: %v)\n", port, host, port, err)
 			}
-			return true
+			return true, nil
 		}
 		_ = l.Close()
 	}
 
-	return false
+	return false, nil
+}
+
+func findAvailableHostPort(start int, dockerAllocated map[int]bool) (int, error) {
+	if start < 1 || start > maxTCPPort {
+		return 0, fmt.Errorf("starting TCP port %d is outside the valid range 1-%d", start, maxTCPPort)
+	}
+	for port := start; port <= maxTCPPort; port++ {
+		inUse, err := isPortInUse(port, dockerAllocated)
+		if err != nil {
+			return 0, err
+		}
+		if !inUse {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available TCP port found from %d through %d", start, maxTCPPort)
 }
 
 // completeAgentNames suggests existing container names for the selected image.
@@ -429,12 +462,12 @@ func ensureContainerRunningWithWorkdirResult(cmd *cobra.Command, cfg config.Conf
 				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to detect allocated Docker ports: %v\n", err)
 			}
 		}
-		chosenPort := cfg.HostStartingPort
 		if isTruthyEnv("DV_VERBOSE") {
-			fmt.Fprintf(cmd.OutOrStdout(), "Searching for an available port starting from %d...\n", chosenPort)
+			fmt.Fprintf(cmd.OutOrStdout(), "Searching for an available port starting from %d...\n", cfg.HostStartingPort)
 		}
-		for isPortInUse(chosenPort, allocated) {
-			chosenPort++
+		chosenPort, err := findAvailableHostPort(cfg.HostStartingPort, allocated)
+		if err != nil {
+			return result, err
 		}
 		if isTruthyEnv("DV_VERBOSE") {
 			fmt.Fprintf(cmd.OutOrStdout(), "Selected port %d.\n", chosenPort)

--- a/internal/cli/shared_test.go
+++ b/internal/cli/shared_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"syscall"
 	"testing"
 
 	"dv/internal/config"
@@ -441,7 +442,10 @@ func TestIsPortInUse_DockerAllocated(t *testing.T) {
 			// To avoid flaky tests from actual port binding, we only test cases where
 			// docker map returns true early, before trying to bind
 			if tt.want {
-				got := isPortInUse(tt.port, tt.allocated)
+				got, err := isPortInUse(tt.port, tt.allocated)
+				if err != nil {
+					t.Fatalf("isPortInUse() error = %v", err)
+				}
 				if got != tt.want {
 					t.Errorf("isPortInUse(%d, %v) = %v, want %v", tt.port, tt.allocated, got, tt.want)
 				}
@@ -464,7 +468,11 @@ func TestIsPortInUse_ActualBinding(t *testing.T) {
 	port := listener.Addr().(*net.TCPAddr).Port
 
 	// The port is now in use by our listener
-	if !isPortInUse(port, nil) {
+	inUse, err := isPortInUse(port, nil)
+	if err != nil {
+		t.Fatalf("isPortInUse() error = %v", err)
+	}
+	if !inUse {
 		t.Errorf("isPortInUse(%d, nil) = false, want true (port is bound)", port)
 	}
 }
@@ -484,12 +492,38 @@ func TestIsPortInUse_AvailablePort(t *testing.T) {
 
 	// Port should now be available (with small race window)
 	// We pass an empty docker map to avoid docker-allocated false positives
-	got := isPortInUse(port, map[int]bool{})
+	got, err := isPortInUse(port, map[int]bool{})
+	if err != nil {
+		t.Fatalf("isPortInUse() error = %v", err)
+	}
 	// Note: This may occasionally fail due to port reuse timing
 	// If this test becomes flaky, we can skip it or use a more robust approach
 	if got {
 		t.Logf("isPortInUse(%d) = true for recently released port (possible race)", port)
 		// Don't fail - this can happen due to TIME_WAIT or port reuse
+	}
+}
+
+func TestIsPortInUse_PropagatesRestrictedNetworkError(t *testing.T) {
+	original := listenTCP
+	listenTCP = func(string, string) (net.Listener, error) {
+		return nil, syscall.EPERM
+	}
+	defer func() { listenTCP = original }()
+
+	inUse, err := isPortInUse(3000, nil)
+	if err == nil || !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("isPortInUse() error = %v, want EPERM", err)
+	}
+	if inUse {
+		t.Fatal("isPortInUse() = true for a permission error")
+	}
+}
+
+func TestFindAvailablePort_StopsAtMaximumPort(t *testing.T) {
+	_, err := findAvailableHostPort(maxTCPPort, map[int]bool{maxTCPPort: true})
+	if err == nil {
+		t.Fatal("findAvailablePort() error = nil, want exhausted range error")
 	}
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -88,12 +88,12 @@ var startCmd = &cobra.Command{
 					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to detect allocated Docker ports: %v\n", err)
 				}
 			}
-			chosenPort := hostPort
 			if isTruthyEnv("DV_VERBOSE") {
-				fmt.Fprintf(cmd.OutOrStdout(), "Searching for an available port starting from %d...\n", chosenPort)
+				fmt.Fprintf(cmd.OutOrStdout(), "Searching for an available port starting from %d...\n", hostPort)
 			}
-			for isPortInUse(chosenPort, allocated) {
-				chosenPort++
+			chosenPort, err := findAvailableHostPort(hostPort, allocated)
+			if err != nil {
+				return err
 			}
 			if isTruthyEnv("DV_VERBOSE") {
 				fmt.Fprintf(cmd.OutOrStdout(), "Selected port %d.\n", chosenPort)
@@ -139,15 +139,19 @@ var startCmd = &cobra.Command{
 				// Remove our own port from the check to avoid false positive remapping
 				delete(allocated, existingPort)
 
-				if isPortInUse(existingPort, allocated) {
+				inUse, err := isPortInUse(existingPort, allocated)
+				if err != nil {
+					return err
+				}
+				if inUse {
 					if noRemap {
 						return fmt.Errorf("port %d is in use; free the port, use --reset to recreate, or remove --no-remap to auto-remap", existingPort)
 					}
 
 					// Find next available port
-					newPort := existingPort
-					for isPortInUse(newPort, allocated) {
-						newPort++
+					newPort, err := findAvailableHostPort(existingPort, allocated)
+					if err != nil {
+						return err
 					}
 
 					fmt.Fprintf(cmd.OutOrStdout(), "Port %d in use, remapping to %d...\n", existingPort, newPort)


### PR DESCRIPTION
## What changed

- stop treating every local TCP bind failure as an occupied port
- return permission and other unexpected bind errors immediately
- bound host-port searches at `math.MaxUint16`
- apply the guarded search everywhere DV selects or remaps a host port

## Why

When DV runs in a restricted network sandbox, `net.Listen` can return `EPERM`. DV previously interpreted that as "port in use" and kept incrementing the port. Once it passed the valid TCP port range, every subsequent bind also failed, leaving `dv start` in an unbounded loop that consumed a CPU core.

## Tests

- added coverage for propagating restricted-network `EPERM` errors
- added coverage for stopping at the maximum TCP port
- `go test ./internal/cli`
- `go test ./...`