### PR TITLE
FEAT: add --discourse-port flag for custom URL ports

### DIFF
--- a/internal/cli/config_local_proxy.go
+++ b/internal/cli/config_local_proxy.go
@@ -73,6 +73,7 @@ var configLocalProxyCmd = &cobra.Command{
 		httpPortFlag, _ := cmd.Flags().GetInt("http-port")
 		httpsPortFlag, _ := cmd.Flags().GetInt("https-port")
 		apiPortFlag, _ := cmd.Flags().GetInt("api-port")
+		discoursePortFlag, _ := cmd.Flags().GetInt("discourse-port")
 		rebuild, _ := cmd.Flags().GetBool("rebuild")
 		recreate, _ := cmd.Flags().GetBool("recreate")
 		public, _ := cmd.Flags().GetBool("public")
@@ -97,6 +98,9 @@ var configLocalProxyCmd = &cobra.Command{
 		}
 		if apiPortFlag > 0 {
 			lp.APIPort = apiPortFlag
+		}
+		if cmd.Flags().Changed("discourse-port") {
+			lp.DiscoursePort = discoursePortFlag
 		}
 		// HTTPS is always off by default, must explicitly pass --https to enable
 		lp.HTTPS = httpsEnabled
@@ -178,6 +182,7 @@ func init() {
 	configLocalProxyCmd.Flags().Bool("https", false, "Enable HTTPS for NAME.dv.localhost using mkcert and redirect HTTP to HTTPS")
 	configLocalProxyCmd.Flags().Int("https-port", 0, "Host port that will listen for HTTPS NAME.dv.localhost requests (defaults to 443 when --https is enabled)")
 	configLocalProxyCmd.Flags().Int("api-port", 0, "Host port for the proxy management API")
+	configLocalProxyCmd.Flags().Int("discourse-port", 0, "Port Discourse uses in generated URLs (default: same as --http-port or --https-port)")
 	configLocalProxyCmd.Flags().Bool("rebuild", false, "Force rebuilding the proxy image even if it exists")
 	configLocalProxyCmd.Flags().Bool("recreate", false, "Remove any existing proxy container before starting")
 	configLocalProxyCmd.Flags().Bool("public", false, "Listen on all network interfaces (default: private/localhost only)")
@@ -196,5 +201,6 @@ func localProxySettingsChanged(prev config.LocalProxyConfig, next config.LocalPr
 		prev.HTTPSPort != next.HTTPSPort ||
 		prev.APIPort != next.APIPort ||
 		prev.Public != next.Public ||
-		prev.Hostname != next.Hostname
+		prev.Hostname != next.Hostname ||
+		prev.DiscoursePort != next.DiscoursePort
 }

--- a/internal/cli/local_proxy_helpers.go
+++ b/internal/cli/local_proxy_helpers.go
@@ -44,13 +44,21 @@ func applyLocalProxyMetadata(cfg config.Config, containerName string, hostPort i
 		envs["DV_LOCAL_PROXY_HTTPS_PORT"] = strconv.Itoa(lp.HTTPSPort)
 		envs["DISCOURSE_FORCE_HTTPS"] = "true"
 		envs["DISCOURSE_DEV_ALLOW_HTTPS"] = "1"
-		// Override DISCOURSE_PORT so URLs use the external HTTPS port, not the internal one
-		envs["DISCOURSE_PORT"] = strconv.Itoa(lp.HTTPSPort)
+		// Override DISCOURSE_PORT so URLs use the external HTTPS port; use DiscoursePort when a different port is needed
+		discoursePort := lp.HTTPSPort
+		if lp.DiscoursePort > 0 {
+			discoursePort = lp.DiscoursePort
+		}
+		envs["DISCOURSE_PORT"] = strconv.Itoa(discoursePort)
 	} else {
 		envs["DV_LOCAL_PROXY_SCHEME"] = "http"
 		envs["DV_LOCAL_PROXY_PORT"] = strconv.Itoa(lp.HTTPPort)
-		// Override DISCOURSE_PORT so URLs use the external HTTP port, not the internal one
-		envs["DISCOURSE_PORT"] = strconv.Itoa(lp.HTTPPort)
+		// Override DISCOURSE_PORT so URLs use the external HTTP port; use DiscoursePort when a different port is needed
+		discoursePort := lp.HTTPPort
+		if lp.DiscoursePort > 0 {
+			discoursePort = lp.DiscoursePort
+		}
+		envs["DISCOURSE_PORT"] = strconv.Itoa(discoursePort)
 	}
 
 	return host

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,6 +164,7 @@ type LocalProxyConfig struct {
 	APIPort       int    `json:"apiPort"`
 	Public        bool   `json:"public"`
 	Hostname      string `json:"hostname,omitempty"`
+	DiscoursePort int    `json:"discoursePort,omitempty"`
 }
 
 func Default() Config {


### PR DESCRIPTION
Before this commit, setting a custom HTTP/HTTPS port also makes Discourse generate URLs on the same port.

This commit adds the `--discourse-port` flag, decoupling the port that the Discourse instance generates from the HTTP/HTTPS ports that are defined by dv. Setting the discourse port to 80/443 will have discourse generate URLs without the port.